### PR TITLE
Wrap IP address in square brackets before passing to net/url

### DIFF
--- a/get_best_stashcache.go
+++ b/get_best_stashcache.go
@@ -88,7 +88,7 @@ func get_best_stashcache(cacheListName string) ([]string, error) {
 		log.Debugf("Trying server site of %s", cur_site)
 
 		for _, ip := range get_ips(cur_site) {
-			GeoIpUrl.Host = ip
+			GeoIpUrl.Host = "[" + ip + "]"
 			GeoIpUrl.Scheme = "http"
 			log.Debugln("Querying", GeoIpUrl.String())
 


### PR DESCRIPTION
IPv6 addresses can be misinterpreted:
```
2021-09-23T21:05:13+0000 root         DEBUG    Querying http://2001:1458:301:73::100:9b/stashservers.dat
2021-09-23T21:05:13+0000 root         DEBUG    Error: nonnumeric port: '9b'
```

Wrapping the IP in square brackets should resolve the issue for IPv6, and does not appear to cause problems for IPv4 with net/url.

<details>
<summary>Test program to show the effects on IPv4 and IPv6 IPs</summary>

```golang
package main

import (
	"fmt"
	"net/url"
)

func parseTest(in string) {
	fmt.Println(in)
	u, err := url.Parse(in)
	if err != nil {
		fmt.Println(err)
		return
	}

	fmt.Println("  url:      " + u.String())
	fmt.Println("  hostname: " + u.Hostname())
	fmt.Println("  port:     " + u.Port())
}

func main() {

	fmt.Println("Current behavior:")
	parseTest("http://131.225.188.246/stashservers.dat")
	parseTest("http://2001:1458:301:73::100:9b/stashservers.dat")
	fmt.Println()

	fmt.Println("Wrapping IPs in brackets:")
	parseTest("http://[131.225.188.246]/stashservers.dat")
	parseTest("http://[2001:1458:301:73::100:9b]/stashservers.dat")

}
```
</details>

<details>
<summary>Test program output</summary>

```
Current behavior:
http://131.225.188.246/stashservers.dat
  url:      http://131.225.188.246/stashservers.dat
  hostname: 131.225.188.246
  port:     
http://2001:1458:301:73::100:9b/stashservers.dat
parse "http://2001:1458:301:73::100:9b/stashservers.dat": invalid port ":9b" after host

Wrapping IPs in brackets:
http://[131.225.188.246]/stashservers.dat
  url:      http://[131.225.188.246]/stashservers.dat
  hostname: 131.225.188.246
  port:     
http://[2001:1458:301:73::100:9b]/stashservers.dat
  url:      http://[2001:1458:301:73::100:9b]/stashservers.dat
  hostname: 2001:1458:301:73::100:9b
  port:     
```
<details>