### PR TITLE
Adding transfer details abstraction for proxy/non-proxy

### DIFF
--- a/handle_http_test.go
+++ b/handle_http_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -20,4 +21,54 @@ func TestIsPort(t *testing.T) {
 		t.Fatal("Failed when scheme is specified")
 	}
 }
+
+// TestNewTransferDetails checks the creation of transfer details
+func TestNewTransferDetails(t *testing.T) {
+	// Case 1: cache with http
+	transfers := NewTransferDetails("cache.edu", false)
+	assert.Equal(t, 2, len(transfers))
+	assert.Equal(t, "cache.edu:8000", transfers[0].Url.Host)
+	assert.Equal(t, "http", transfers[0].Url.Scheme)
+	assert.Equal(t, true, transfers[0].Proxy)
+	assert.Equal(t, "cache.edu:8000", transfers[1].Url.Host)
+	assert.Equal(t, "http", transfers[1].Url.Scheme)
+	assert.Equal(t, false, transfers[1].Proxy)
+
+	// Case 2: cache with https
+	transfers = NewTransferDetails("cache.edu", true)
+	assert.Equal(t, 4, len(transfers))
+	assert.Equal(t, "cache.edu:8444", transfers[0].Url.Host)
+	assert.Equal(t, "https", transfers[0].Url.Scheme)
+	assert.Equal(t, true, transfers[0].Proxy)
+	assert.Equal(t, "cache.edu:8444", transfers[1].Url.Host)
+	assert.Equal(t, "https", transfers[1].Url.Scheme)
+	assert.Equal(t, false, transfers[1].Proxy)
+	assert.Equal(t, "cache.edu:8443", transfers[2].Url.Host)
+	assert.Equal(t, "https", transfers[1].Url.Scheme)
+	assert.Equal(t, true, transfers[2].Proxy)
+	assert.Equal(t, "cache.edu:8443", transfers[3].Url.Host)
+	assert.Equal(t, "https", transfers[3].Url.Scheme)
+	assert.Equal(t, false, transfers[3].Proxy)
+
+	// Case 3: cache with port with http
+	transfers = NewTransferDetails("cache.edu:1234", false)
+	assert.Equal(t, 2, len(transfers))
+	assert.Equal(t, "cache.edu:1234", transfers[0].Url.Host)
+	assert.Equal(t, "http", transfers[0].Url.Scheme)
+	assert.Equal(t, true, transfers[0].Proxy)
+	assert.Equal(t, "cache.edu:1234", transfers[1].Url.Host)
+	assert.Equal(t, "http", transfers[1].Url.Scheme)
+	assert.Equal(t, false, transfers[1].Proxy)
+
+	// Case 4. cache with port with https
+	transfers = NewTransferDetails("cache.edu:5678", true)
+	assert.Equal(t, 2, len(transfers))
+	assert.Equal(t, "cache.edu:5678", transfers[0].Url.Host)
+	assert.Equal(t, "https", transfers[0].Url.Scheme)
+	assert.Equal(t, true, transfers[0].Proxy)
+	assert.Equal(t, "cache.edu:5678", transfers[1].Url.Host)
+	assert.Equal(t, "https", transfers[1].Url.Scheme)
+	assert.Equal(t, false, transfers[1].Proxy)
+}
+
 


### PR DESCRIPTION
When downloading with HTTP, it will try both using the http_proxy,
and without for each host.

Also added tests.