### PR TITLE
Add env OSG_DISABLE_PROXY_FALLBACK to disable proxy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Run this simple command to download a test file
     $ ./stashcp /osgconnect/public/dweitzel/blast/queries/query1 ./
 
 
+Configuration
+-------------
+`stashcp` is affected by the environment variables:
+
+| Environment Variable      | Description |
+| ----------- | ----------- |
+| `OSG_DISABLE_PROXY_FALLBACK`      | Do not disable using proxies. By default, `stashcp` will try to use an HTTP proxy when connecting to a cache. If this environment variable is set (no value necessary, only if it's set), then `stashcp` will not fallback to no proxy if the proxy download fails.         |
+
+

--- a/handle_http.go
+++ b/handle_http.go
@@ -36,6 +36,10 @@ type TransferDetails struct {
 func NewTransferDetails(cache string, https bool) []TransferDetails {
 	details := make([]TransferDetails, 0)
 
+
+	_, canDisableProxy := os.LookupEnv("OSG_DISABLE_PROXY_FALLBACK")
+	canDisableProxy = !canDisableProxy
+
 	// Form the URL
 	cacheURL, err := url.Parse(cache)
 	if err != nil {
@@ -55,29 +59,34 @@ func NewTransferDetails(cache string, https bool) []TransferDetails {
 			cacheURL.Host += ":8444"
 			details = append(details, TransferDetails{
 				Url:   *cacheURL,
-				Proxy: true,
-			})
-			details = append(details, TransferDetails{
-				Url:   *cacheURL,
 				Proxy: false,
 			})
 			// Strip the port off and add 8443
 			cacheURL.Host = cacheURL.Host[:len(cacheURL.Host) - 5] + ":8443"
 		}
+		// Whether port is specified or not, add a transfer without proxy
+		details = append(details, TransferDetails{
+			Url:   *cacheURL,
+			Proxy: false,
+		})
 	} else {
 		cacheURL.Scheme = "http"
 		if !HasPort(cacheURL.Host) {
 			cacheURL.Host += ":8000"
 		}
+		details = append(details, TransferDetails{
+			Url:   *cacheURL,
+			Proxy: true,
+		})
+		if canDisableProxy {
+			details = append(details, TransferDetails{
+				Url:   *cacheURL,
+				Proxy: false,
+			})
+		}
 	}
-	details = append(details, TransferDetails{
-		Url:   *cacheURL,
-		Proxy: true,
-	})
-	details = append(details, TransferDetails{
-		Url:   *cacheURL,
-		Proxy: false,
-	})
+
+
 	return details
 }
 

--- a/handle_http_test.go
+++ b/handle_http_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
 )
 
@@ -36,19 +37,13 @@ func TestNewTransferDetails(t *testing.T) {
 
 	// Case 2: cache with https
 	transfers = NewTransferDetails("cache.edu", true)
-	assert.Equal(t, 4, len(transfers))
+	assert.Equal(t, 2, len(transfers))
 	assert.Equal(t, "cache.edu:8444", transfers[0].Url.Host)
 	assert.Equal(t, "https", transfers[0].Url.Scheme)
-	assert.Equal(t, true, transfers[0].Proxy)
-	assert.Equal(t, "cache.edu:8444", transfers[1].Url.Host)
+	assert.Equal(t, false, transfers[0].Proxy)
+	assert.Equal(t, "cache.edu:8443", transfers[1].Url.Host)
 	assert.Equal(t, "https", transfers[1].Url.Scheme)
 	assert.Equal(t, false, transfers[1].Proxy)
-	assert.Equal(t, "cache.edu:8443", transfers[2].Url.Host)
-	assert.Equal(t, "https", transfers[1].Url.Scheme)
-	assert.Equal(t, true, transfers[2].Proxy)
-	assert.Equal(t, "cache.edu:8443", transfers[3].Url.Host)
-	assert.Equal(t, "https", transfers[3].Url.Scheme)
-	assert.Equal(t, false, transfers[3].Proxy)
 
 	// Case 3: cache with port with http
 	transfers = NewTransferDetails("cache.edu:1234", false)
@@ -62,13 +57,23 @@ func TestNewTransferDetails(t *testing.T) {
 
 	// Case 4. cache with port with https
 	transfers = NewTransferDetails("cache.edu:5678", true)
-	assert.Equal(t, 2, len(transfers))
+	assert.Equal(t, 1, len(transfers))
 	assert.Equal(t, "cache.edu:5678", transfers[0].Url.Host)
 	assert.Equal(t, "https", transfers[0].Url.Scheme)
-	assert.Equal(t, true, transfers[0].Proxy)
-	assert.Equal(t, "cache.edu:5678", transfers[1].Url.Host)
-	assert.Equal(t, "https", transfers[1].Url.Scheme)
-	assert.Equal(t, false, transfers[1].Proxy)
+	assert.Equal(t, false, transfers[0].Proxy)
 }
 
+func TestNewTransferDetailsEnv(t *testing.T) {
+	os.Setenv("OSG_DISABLE_PROXY_FALLBACK", "")
+	transfers := NewTransferDetails("cache.edu", false)
+	assert.Equal(t, 1, len(transfers))
+	assert.Equal(t, true, transfers[0].Proxy)
+
+	transfers = NewTransferDetails("cache.edu", true)
+	assert.Equal(t, 2, len(transfers))
+	assert.Equal(t, "https", transfers[0].Url.Scheme)
+	assert.Equal(t, false, transfers[0].Proxy)
+	assert.Equal(t, false, transfers[1].Proxy)
+	os.Unsetenv("OSG_DISABLE_PROXY_FALLBACK")
+}
 


### PR DESCRIPTION
If OSG_DISABLE_PROXY_FALLBACK is in the environment, then do not
fallback to not using a proxy if the download fails through the
proxy.  But, never use a proxy for HTTPS.