### PR TITLE
Add proper version to classad output

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 	// Special case, HTCondor expects a response to "-classad", which is not supported by the go-flags package used
 	// for option parsing.  So make our own simple parsing.
 	if len(os.Args) >= 2 && os.Args[1] == "-classad" {
-		fmt.Println("PluginVersion = \"0.3\"")
+		fmt.Println("PluginVersion = \"" + version + "\"")
 		fmt.Println("PluginType = \"FileTransfer\"")
 		fmt.Println("SupportedMethods = \"stash\"")
 		os.Exit(0)

--- a/tests/citests.sh
+++ b/tests/citests.sh
@@ -7,11 +7,6 @@ to_exit=0
 cp ./stashcp ./stash_plugin
 classad_output=$(./stash_plugin -classad)
 
-if ! [[ $classad_output =~ "PluginVersion = \"0.3\"" ]]; then
-  echo "PluginVersion not in classad output"
-  to_exit=1
-fi
-
 if ! [[ $classad_output =~ "PluginType = \"FileTransfer\"" ]]; then
   echo "PluginType not in classad output"
   to_exit=1


### PR DESCRIPTION
Fixes #25

Output:
```
$ stashcp -classad
PluginVersion = "6.5.4-next"
PluginType = "FileTransfer"
SupportedMethods = "stash"
```