### PR TITLE
Change log lvl of failure to download namespace to debug

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -112,7 +112,7 @@ func GetNamespaces() ([]Namespace, error) {
 	// Try downloading the namespaces, if it fails, use the embedded namespaces
 	namespacesFromUrl, err := downloadNamespace()
 	if err != nil {
-		log.Warningf("Failed to download namespaces: %s", err)
+		log.Debugf("Failed to download namespaces: %s, continueing using built-in namespace configuration", err)
 	} else {
 		namespacesJson = namespacesFromUrl
 	}


### PR DESCRIPTION
Failure to download namespace will result in using the compiled-in
namespace configuration.

Fixes #45